### PR TITLE
feat(serialization): Use reactivemongo-bson as serialization lib

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ enablePlugins(
 
 def scalacOptionsVersion(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
   case Some((2, 13)) => Seq("-Wunused")
+  case Some((2, 12)) => Seq("-Xlint:unused")
   case _             => Nil
 }
 
@@ -41,17 +42,14 @@ lazy val core = (project in file("modules/core"))
   .settings(
     name := "dappermongo-core",
     libraryDependencies ++= Seq(
-      "dev.zio"    %% "zio"                            % "2.0.21",
-      "dev.zio"    %% "zio-streams"                    % "2.0.21",
-      "dev.zio"    %% "zio-interop-reactivestreams"    % "2.0.2",
-      "dev.zio"    %% "zio-bson"                       % "1.0.5",
-      "org.mongodb" % "mongodb-driver-reactivestreams" % "4.11.0",
-//      "org.reactivemongo" %% "reactivemongo-bson-msb-compat"  % "1.1.0-RC12",
-      "dev.zio"      %% "zio-schema-bson"              % "0.4.17"  % Test,
-      "dev.zio"      %% "zio-schema-derivation"        % "0.4.17"  % Test,
-      "dev.zio"      %% "zio-test"                     % "2.0.21"  % Test,
-      "dev.zio"      %% "zio-test-sbt"                 % "2.0.21"  % Test,
-      "com.dimafeng" %% "testcontainers-scala-mongodb" % "0.40.12" % Test
+      "dev.zio"           %% "zio"                            % "2.0.21",
+      "dev.zio"           %% "zio-streams"                    % "2.0.21",
+      "dev.zio"           %% "zio-interop-reactivestreams"    % "2.0.2",
+      "org.mongodb"        % "mongodb-driver-reactivestreams" % "4.11.0",
+      "org.reactivemongo" %% "reactivemongo-bson-msb-compat"  % "1.1.0-RC12",
+      "dev.zio"           %% "zio-test"                       % "2.0.21"  % Test,
+      "dev.zio"           %% "zio-test-sbt"                   % "2.0.21"  % Test,
+      "com.dimafeng"      %% "testcontainers-scala-mongodb"   % "0.40.12" % Test
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     Test / fork   := true,

--- a/modules/core/src/main/scala-2.12/dappermongo/internal/CollectionConversionsVersionSpecific.scala
+++ b/modules/core/src/main/scala-2.12/dappermongo/internal/CollectionConversionsVersionSpecific.scala
@@ -1,0 +1,19 @@
+package dappermongo.internal
+
+import scala.collection.JavaConverters._
+
+private[dappermongo] trait CollectionConversionsVersionSpecific {
+
+  def seqAsJava[T](seq: Seq[T]): java.util.List[T] =
+    seq.asJava
+
+  def listAsScala[T](list: java.util.List[T]): Seq[T] =
+    list.asScala.toSeq
+
+  def iterableAsScala[T](iterable: java.lang.Iterable[T]): Iterable[T] =
+    iterable.asScala
+
+  def collectionAsJava[T](collection: Iterable[T]): java.util.Collection[T] =
+    collection.asJavaCollection
+
+}

--- a/modules/core/src/main/scala-2.13/dappermongo/internal/CollectionConversionsVersionSpecific.scala
+++ b/modules/core/src/main/scala-2.13/dappermongo/internal/CollectionConversionsVersionSpecific.scala
@@ -1,0 +1,19 @@
+package dappermongo.internal
+
+import scala.jdk.CollectionConverters._
+
+private[dappermongo] trait CollectionConversionsVersionSpecific {
+
+  def seqAsJava[T](seq: Seq[T]): java.util.List[T] =
+    seq.asJava
+
+  def listAsScala[T](list: java.util.List[T]): Seq[T] =
+    list.asScala.toSeq
+
+  def iterableAsScala[T](iterable: java.lang.Iterable[T]): Iterable[T] =
+    iterable.asScala
+
+  def collectionAsJava[T](collection: Iterable[T]): java.util.Collection[T] =
+    collection.asJavaCollection
+
+}

--- a/modules/core/src/main/scala-3/dappermongo/internal/CollectionConversionsVersionSpecific.scala
+++ b/modules/core/src/main/scala-3/dappermongo/internal/CollectionConversionsVersionSpecific.scala
@@ -1,0 +1,19 @@
+package dappermongo.internal
+
+import scala.jdk.CollectionConverters.*
+
+private[dappermongo] trait CollectionConversionsVersionSpecific {
+
+  def seqAsJava[T](seq: Seq[T]): java.util.List[T] =
+    seq.asJava
+
+  def listAsScala[T](list: java.util.List[T]): Seq[T] =
+    list.asScala.toSeq
+
+  def iterableAsScala[T](iterable: java.lang.Iterable[T]): Iterable[T] =
+    iterable.asScala
+
+  def collectionAsJava[T](collection: Iterable[T]): java.util.Collection[T] =
+    collection.asJavaCollection
+
+}

--- a/modules/core/src/main/scala/dappermongo/results/InsertedOne.scala
+++ b/modules/core/src/main/scala/dappermongo/results/InsertedOne.scala
@@ -1,11 +1,11 @@
 package dappermongo.results
 
-import org.bson.BsonValue
+import reactivemongo.api.bson.BSONValue
 
 case class InsertedOne(
-  insertedId: Option[BsonValue]
+  insertedId: Option[BSONValue]
 )
 
 case class InsertedMany(
-  insertedIds: Map[Int, BsonValue]
+  insertedIds: Map[Int, BSONValue]
 )

--- a/modules/core/src/main/scala/dappermongo/results/Updated.scala
+++ b/modules/core/src/main/scala/dappermongo/results/Updated.scala
@@ -1,9 +1,9 @@
 package dappermongo.results
 
-import org.bson.BsonValue
+import reactivemongo.api.bson.BSONValue
 
 case class Updated(
   matched: Long,
   modified: Long,
-  upsertedId: Option[BsonValue]
+  upsertedId: Option[BSONValue]
 )

--- a/modules/core/src/test/scala/dappermongo/QuerySpec.scala
+++ b/modules/core/src/test/scala/dappermongo/QuerySpec.scala
@@ -1,17 +1,14 @@
 package dappermongo
 
+import reactivemongo.api.bson.{BSONDocumentHandler, Macros}
 import zio._
-import zio.bson.BsonCodec
-import zio.schema.codec.BsonSchemaCodec
-import zio.schema.{DeriveSchema, Schema}
 import zio.test.{TestAspect, assertTrue}
 
 object QuerySpec extends MongoITSpecDefault {
   case class Person(name: String, age: Int)
 
   object Person {
-    val schema: Schema[Person]            = DeriveSchema.gen[Person]
-    implicit val codec: BsonCodec[Person] = BsonSchemaCodec.bsonCodec(schema)
+    implicit val codec: BSONDocumentHandler[Person] = Macros.handler[Person]
   }
 
   val spec = suite("Query")(


### PR DESCRIPTION
The built in java types aren't very "scala-like", by contrast the reactivemongo-bson project is well developed and built from the ground up in scala. Plus it is built for scala 2.12-3 unline the mongo-scala wrapper library.