### PR TITLE
Fix transactions api

### DIFF
--- a/modules/core/src/main/scala/dappermongo/AggregateOps.scala
+++ b/modules/core/src/main/scala/dappermongo/AggregateOps.scala
@@ -1,13 +1,10 @@
 package dappermongo
-
-import scala.util.Try
-
 import com.mongodb.reactivestreams.client.{ClientSession, MongoDatabase}
 import dappermongo.aggregate.Pipeline
 import dappermongo.internal.{CollectionConversionsVersionSpecific, _}
 import org.bson.RawBsonDocument
 import reactivemongo.api.bson.msb._
-import reactivemongo.api.bson.{BSON, BSONDocument, BSONDocumentReader, BSONDocumentWriter}
+import reactivemongo.api.bson.{BSON, BSONDocumentReader, BSONDocumentWriter}
 import zio.stream.ZStream
 import zio.{Duration, ZIO}
 
@@ -68,10 +65,10 @@ object AggregateBuilder {
       copy(options = options.copy(collation = collation))
 
     override def comment[T: BSONDocumentWriter](comment: T): AggregateBuilder[Collection] =
-      copy(options = options.copy(comment = Some(() => BSON.writeDocument(comment))))
+      copy(options = options.copy(comment = Some(DocumentEncodedFn(BSON.writeDocument(comment)))))
 
     override def hint[T: BSONDocumentWriter](hint: T): AggregateBuilder[Collection] =
-      copy(options = options.copy(hint = Some(() => BSON.writeDocument(hint))))
+      copy(options = options.copy(hint = Some(DocumentEncodedFn(BSON.writeDocument(hint)))))
 
     override def maxTime(maxTime: Duration): AggregateBuilder[Collection] =
       copy(options = options.copy(maxTime = Some(maxTime)))
@@ -137,8 +134,8 @@ object AggregateBuilder {
     batchSize: Option[Int] = None,
     bypassDocumentValidation: Option[Boolean] = None,
     collation: Option[Collation] = None,
-    comment: Option[() => Try[BSONDocument]] = None,
-    hint: Option[() => Try[BSONDocument]] = None,
+    comment: Option[DocumentEncodedFn] = None,
+    hint: Option[DocumentEncodedFn] = None,
     maxTime: Option[Duration] = None,
     maxAwaitTime: Option[Duration] = None
   )

--- a/modules/core/src/main/scala/dappermongo/CountOps.scala
+++ b/modules/core/src/main/scala/dappermongo/CountOps.scala
@@ -96,7 +96,7 @@ object CountBuilder {
               session
                 .fold(coll.countDocuments(query, countOptions))(coll.countDocuments(_, query, countOptions))
                 .single
-                .map(_.fold(0L)(Long.box(_)))
+                .map(_.fold[Long](0L)(identity(_)))
             })
             .flatten
         }

--- a/modules/core/src/main/scala/dappermongo/Database.scala
+++ b/modules/core/src/main/scala/dappermongo/Database.scala
@@ -1,6 +1,6 @@
 package dappermongo
 
-import com.mongodb.reactivestreams.client.MongoDatabase
+import com.mongodb.reactivestreams.client.{ClientSession, MongoDatabase}
 import dappermongo.aggregate.Pipeline
 import dappermongo.internal.DocumentEncodedFn
 import reactivemongo.api.bson.BSONDocumentWriter
@@ -21,7 +21,8 @@ trait Database
 
 object Database {
 
-  private[dappermongo] def apply(database: MongoDatabase): Database = Impl(database)
+  private[dappermongo] def apply(database: MongoDatabase, sessionStorage: SessionStorage[ClientSession]): Database =
+    Impl(database, sessionStorage)
 
   def make(dbName: String): ZIO[MongoClient, Throwable, Database] =
     ZIO.serviceWithZIO[MongoClient](_.database(dbName))
@@ -29,16 +30,16 @@ object Database {
   def named(dbName: String): ZLayer[MongoClient, Throwable, Database] =
     ZLayer(make(dbName))
 
-  private case class Impl(database: MongoDatabase) extends Database {
+  private case class Impl(database: MongoDatabase, sessionStorage: SessionStorage[ClientSession]) extends Database {
     self =>
     override def collection(name: String): Collection = Collection(name)
 
-    override def delete: DeleteBuilder[Collection] = DeleteBuilder(database)
-    override def update: UpdateBuilder[Collection] = UpdateBuilder(database)
-    override def insert: InsertBuilder[Collection] = InsertBuilder(database)
-    override def findAll: FindBuilder[Collection]  = FindBuilder(database)
+    override def delete: DeleteBuilder[Collection] = DeleteBuilder(database, sessionStorage)
+    override def update: UpdateBuilder[Collection] = UpdateBuilder(database, sessionStorage)
+    override def insert: InsertBuilder[Collection] = InsertBuilder(database, sessionStorage)
+    override def findAll: FindBuilder[Collection]  = FindBuilder(database, QueryBuilderOptions(), sessionStorage)
     override def find[Q](q: Q)(implicit ev: BSONDocumentWriter[Q]): FindBuilder[Collection] =
-      FindBuilder(database, QueryBuilderOptions(filter = Some(DocumentEncodedFn(ev.writeTry(q)))))
+      FindBuilder(database, QueryBuilderOptions(filter = Some(DocumentEncodedFn(ev.writeTry(q)))), sessionStorage)
 
     override def find[Q, P](query: Q, projection: P)(implicit
       evQ: BSONDocumentWriter[Q],
@@ -49,18 +50,20 @@ object Database {
         QueryBuilderOptions(
           filter = Some(DocumentEncodedFn(evQ.writeTry(query))),
           projection = Some(DocumentEncodedFn(evP.writeTry(projection)))
-        )
+        ),
+        sessionStorage
       )
 
-    override def index: IndexBuilder[Collection] = IndexBuilder.Impl(database)
+    override def index: IndexBuilder[Collection] = IndexBuilder.Impl(database, sessionStorage)
 
-    override def distinct(field: String): DistinctBuilder[Collection] = DistinctBuilder(database, field)
+    override def distinct(field: String): DistinctBuilder[Collection] = DistinctBuilder(database, field, sessionStorage)
 
-    override def replace: ReplaceBuilder[Collection] = ReplaceBuilder(database)
+    override def replace: ReplaceBuilder[Collection] = ReplaceBuilder(database, sessionStorage)
 
-    override def count: CountBuilder[Collection] = CountBuilder(database)
+    override def count: CountBuilder[Collection] = CountBuilder(database, sessionStorage)
 
-    override def aggregate(pipeline: Pipeline): AggregateBuilder[Collection] = AggregateBuilder(database, pipeline)
+    override def aggregate(pipeline: Pipeline): AggregateBuilder[Collection] =
+      AggregateBuilder(database, pipeline, sessionStorage)
   }
 
 }

--- a/modules/core/src/main/scala/dappermongo/DistinctOps.scala
+++ b/modules/core/src/main/scala/dappermongo/DistinctOps.scala
@@ -1,12 +1,13 @@
 package dappermongo
 
 import com.mongodb.reactivestreams.client.{ClientSession, DistinctPublisher, MongoDatabase}
+import dappermongo.internal.{DocumentEncodedFn, traverseOption}
 import java.util.concurrent.TimeUnit
 import org.bson.RawBsonDocument
 import reactivemongo.api.bson.msb._
-import reactivemongo.api.bson.{BSON, BSONDocument, BSONDocumentWriter, BSONReader, document}
-import zio.stream.ZSink
-import zio.{Chunk, Duration, ZIO}
+import reactivemongo.api.bson.{BSON, BSONDocumentWriter, BSONReader, document}
+import zio.stream.{ZSink, ZStream}
+import zio.{Chunk, Duration, Task, ZIO}
 
 import zio.interop.reactivestreams.publisherToStream
 
@@ -42,7 +43,7 @@ object DistinctBuilder {
     Impl(mongoDatabase, field, sessionStorage)
 
   private case class DistinctBuilderOptions(
-    filter: Option[() => BSONDocument] = None,
+    filter: Option[DocumentEncodedFn] = None,
     maxTime: Option[Duration] = None,
     collation: Option[Collation] = None,
     batchSize: Option[Int] = None,
@@ -55,7 +56,7 @@ object DistinctBuilder {
     options: DistinctBuilderOptions = DistinctBuilderOptions()
   ) extends DistinctBuilder[Collection] {
     override def filter[T](filter: T)(implicit ev: BSONDocumentWriter[T]): DistinctBuilder[Collection] =
-      copy(options = options.copy(filter = Some(() => ev.writeTry(filter).get)))
+      copy(options = options.copy(filter = Some(DocumentEncodedFn(ev.writeTry(filter)))))
 
     override def maxTime(maxTime: Duration): DistinctBuilder[Collection] =
       copy(options = options.copy(maxTime = Some(maxTime)))
@@ -78,8 +79,8 @@ object DistinctBuilder {
     private def to[T: BSONReader, Out](sink: ZSink[Any, Throwable, T, Nothing, Out]): ZIO[Collection, Throwable, Out] =
       ZIO.serviceWithZIO { collection =>
         sessionStorage.get.flatMap { session =>
-          makePublisher(session, collection, options)
-            .toZIOStream()
+          ZStream
+            .unwrap(makePublisher(session, collection, options).map(_.toZIOStream()))
             .map(doc => BSON.read[T](doc).fold(Left(_), Right(_)))
             .absolve
             .run(sink)
@@ -90,22 +91,26 @@ object DistinctBuilder {
       session: Option[ClientSession],
       collection: Collection,
       options: DistinctBuilderOptions
-    ): DistinctPublisher[RawBsonDocument] = {
-      val coll       = database.getCollection(collection.name, classOf[org.bson.RawBsonDocument])
-      val filter     = fromDocument(options.filter.map(_.apply()).getOrElse(document))
-      val collation0 = options.collation.map(_.asJava).orNull
-      val publisher = {
-        session.fold(coll.distinct(field, filter, classOf[RawBsonDocument]))(
-          coll.distinct(_, field, filter, classOf[RawBsonDocument])
-        )
+    ): Task[DistinctPublisher[RawBsonDocument]] = ZIO.fromTry {
+      val coll = database.getCollection(collection.name, classOf[org.bson.RawBsonDocument])
+      for {
+        maybeFilter <- traverseOption(options.filter.map(_.apply()))
+      } yield {
+        val filter     = fromDocument(maybeFilter.getOrElse(document))
+        val collation0 = options.collation.map(_.asJava).orNull
+        val publisher = {
+          session.fold(coll.distinct(field, filter, classOf[RawBsonDocument]))(
+            coll.distinct(_, field, filter, classOf[RawBsonDocument])
+          )
+        }
+
+        options.batchSize.foreach(publisher.batchSize)
+        options.comment.foreach(publisher.comment)
+        options.maxTime.foreach(d => publisher.maxTime(d.toMillis, TimeUnit.MILLISECONDS))
+        publisher.collation(collation0)
+
+        publisher
       }
-
-      options.batchSize.foreach(publisher.batchSize)
-      options.comment.foreach(publisher.comment)
-      options.maxTime.foreach(d => publisher.maxTime(d.toMillis, TimeUnit.MILLISECONDS))
-      publisher.collation(collation0)
-
-      publisher
     }
   }
 }

--- a/modules/core/src/main/scala/dappermongo/MongoClient.scala
+++ b/modules/core/src/main/scala/dappermongo/MongoClient.scala
@@ -58,7 +58,7 @@ object MongoClient {
   def fromSettings(settings: MongoSettings): ZIO[Scope, Throwable, MongoClient] =
     ZIO
       .fromAutoCloseable(ZIO.attempt(MongoClients.create(settings.toJava, driverInformation)))
-      .map(Impl.apply)
+      .flatMap(client => SessionStorage.fiberRef[ClientSession].map(Impl.apply(client, _)))
 
   private lazy val driverInformation =
     MongoDriverInformation
@@ -68,9 +68,9 @@ object MongoClient {
       .driverPlatform("zio")
       .build()
 
-  private case class Impl(client: JMongoClient) extends MongoClient {
+  private case class Impl(client: JMongoClient, sessionStorage: SessionStorage[ClientSession]) extends MongoClient {
     override def database(name: String): ZIO[Any, Throwable, Database] =
-      ZIO.attempt(client.getDatabase(name)).map(Database.apply)
+      ZIO.attempt(client.getDatabase(name)).map(Database.apply(_, sessionStorage))
 
     override def listDatabaseNames: ZStream[Any, Throwable, String] =
       ZStream.suspend(client.listDatabaseNames().toZIOStream())
@@ -83,7 +83,7 @@ object MongoClient {
             .single
             .someOrFailException
         )
-        .map(Session.apply)
+        .map(Session.apply(_, sessionStorage))
   }
 
   private[dappermongo] val sessionRef =

--- a/modules/core/src/main/scala/dappermongo/MongoClient.scala
+++ b/modules/core/src/main/scala/dappermongo/MongoClient.scala
@@ -83,15 +83,13 @@ object MongoClient {
             .single
             .someOrFailException
         )
-        .flatMap(Session.make)
+        .map(Session.apply)
   }
 
-  private[dappermongo] val stateRef =
-    Unsafe.unsafe(implicit u => FiberRef.unsafe.make[State](State(None, transacting = false)))
+  private[dappermongo] val sessionRef =
+    Unsafe.unsafe(implicit u => FiberRef.unsafe.make[Option[ClientSession]](None))
 
-  private[dappermongo] val currentSession: ZIO[Any, Nothing, Option[ClientSession]] =
-    stateRef.get.map(state => state.session.filter(_ => state.transacting))
-
-  private[dappermongo] case class State(session: Option[ClientSession], transacting: Boolean)
+  private[dappermongo] val currentSession =
+    sessionRef.get
 
 }

--- a/modules/core/src/main/scala/dappermongo/Session.scala
+++ b/modules/core/src/main/scala/dappermongo/Session.scala
@@ -2,7 +2,7 @@ package dappermongo
 
 import com.mongodb.reactivestreams.client.ClientSession
 import dappermongo.Session.TransactionRestorer
-import zio.{Exit, Scope, ZIO}
+import zio.{Exit, Scope, Trace, ZIO, ZIOAspect}
 
 import dappermongo.internal.PublisherOps
 
@@ -15,6 +15,12 @@ trait Session {
 
   def transactionalMask[R, E, A](k: TransactionRestorer => ZIO[R, E, A]): ZIO[R, E, A]
 
+  def transactionally: ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+    new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
+      override def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+        transactional(zio)
+    }
+
 }
 
 object Session {
@@ -26,33 +32,25 @@ object Session {
     def apply(current: Option[ClientSession]): TransactionRestorer =
       new TransactionRestorer {
         override def apply[R, E, A](effect: => ZIO[R, E, A]): ZIO[R, E, A] =
-          MongoClient.stateRef.locallyWith(_.copy(session = current))(effect)
+          MongoClient.sessionRef.locally(current)(effect)
       }
   }
-
-  def make(session: ClientSession): ZIO[Scope, Nothing, Session] =
-    for {
-      _ <- MongoClient.stateRef.locallyScopedWith(_.copy(session = Some(session)))
-    } yield apply(session)
 
   private[dappermongo] def apply(session: ClientSession): Session =
     Impl(session)
 
   private case class Impl(session: ClientSession) extends Session {
-    override def transactionScoped: ZIO[Scope, Throwable, Unit] = {
-      def transacting(t: Boolean) = MongoClient.stateRef.update(_.copy(transacting = t))
-
+    override def transactionScoped: ZIO[Scope, Throwable, Unit] =
       ZIO.acquireReleaseExit(
-        ZIO.attempt(session.startTransaction()) *> transacting(true)
+        ZIO.attempt(session.startTransaction())
       ) {
-        case (_, Exit.Success(_)) => transacting(false) *> session.commitTransaction().empty.orDie
-        case (_, Exit.Failure(_)) => transacting(false) *> session.abortTransaction().empty.orDie
-      }
-    }
+        case (_, Exit.Success(_)) => session.commitTransaction().empty.orDie
+        case (_, Exit.Failure(_)) => session.abortTransaction().empty.orDie
+      } <* MongoClient.sessionRef.locallyScoped(Some(session))
 
     override def transactionalMask[R, E, A](k: TransactionRestorer => ZIO[R, E, A]): ZIO[R, E, A] =
       ZIO.scoped[R](for {
-        current <- MongoClient.currentSession.debug("current session")
+        current <- MongoClient.sessionRef.get
         restorer = TransactionRestorer(current)
         result  <- transactionScoped.orDie *> k(restorer)
       } yield result)

--- a/modules/core/src/main/scala/dappermongo/SessionStorage.scala
+++ b/modules/core/src/main/scala/dappermongo/SessionStorage.scala
@@ -1,0 +1,31 @@
+package dappermongo
+
+import zio.{FiberRef, Scope, UIO, URIO, ZIO}
+
+private[dappermongo] trait SessionStorage[Session] {
+
+  def get: UIO[Option[Session]]
+
+  def locallyScoped(value: Option[Session]): URIO[Scope, Unit]
+
+  def locally[R, E, B](newValue: Option[Session])(zio: ZIO[R, E, B]): ZIO[R, E, B]
+
+}
+
+object SessionStorage {
+
+  def fiberRef[Session]: ZIO[Scope, Nothing, SessionStorage[Session]] =
+    for {
+      ref <- FiberRef.make[Option[Session]](None)
+    } yield new SessionStorage[Session] {
+      override def get: UIO[Option[Session]] =
+        ref.get
+
+      override def locallyScoped(value: Option[Session]): URIO[Scope, Unit] =
+        ref.locallyScoped(value)
+
+      override def locally[R, E, B](newValue: Option[Session])(zio: ZIO[R, E, B]): ZIO[R, E, B] =
+        ref.locally(newValue)(zio)
+    }
+
+}

--- a/modules/core/src/main/scala/dappermongo/internal/DocumentEncodedFn.scala
+++ b/modules/core/src/main/scala/dappermongo/internal/DocumentEncodedFn.scala
@@ -1,0 +1,13 @@
+package dappermongo.internal
+
+import scala.util.Try
+
+import reactivemongo.api.bson.BSONDocument
+
+private[dappermongo] class DocumentEncodedFn(fn: => Try[BSONDocument]) extends (() => Try[BSONDocument]) {
+  override def apply(): Try[BSONDocument] = fn
+}
+
+object DocumentEncodedFn {
+  def apply(fn: => Try[BSONDocument]): DocumentEncodedFn = new DocumentEncodedFn(fn)
+}

--- a/modules/core/src/main/scala/dappermongo/internal/package.scala
+++ b/modules/core/src/main/scala/dappermongo/internal/package.scala
@@ -1,5 +1,7 @@
 package dappermongo
 
+import scala.util.{Success, Try}
+
 import org.reactivestreams.Publisher
 import zio.interop.reactivestreams.internal.{EmptySubscriber, SingleSubscriber}
 import zio.{Task, ZIO}
@@ -16,4 +18,10 @@ package object internal {
       subscriber.await.onInterrupt(subscriber.interrupt).unit
     })
   }
+
+  private[dappermongo] def traverseOption[A](option: Option[Try[A]]): Try[Option[A]] =
+    option match {
+      case Some(value) => value.map(Some(_))
+      case None        => Success(None)
+    }
 }


### PR DESCRIPTION
Previously the Transaction API could not handle multiple overlapping client usages. This PR fixes that behavior and better aligns the use of the transaction API with how it is implemented in the driver.  Also refactored the anonymous usage of `() => BSONDocument` to have a helper type instead. 